### PR TITLE
github: Drop redundant Cache Go Modules step

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -98,16 +98,6 @@ jobs:
         repository: ${{ inputs.jepsen-cowsql-repo || github.repository }}
         ref: ${{ inputs.jepsen-cowsql-ref || github.ref }}
 
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Cache Jepsen (lein project) dependencies
       uses: actions/cache@v3
       with:

--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -117,7 +117,7 @@ jobs:
           ${{ runner.os }}-clojure
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
 
     - name: Setup environment
       timeout-minutes: 15


### PR DESCRIPTION
The actions/setup-go@v4 step already takes care of caching Go modules for future builds.
