### PR TITLE
db: Fix kill! and stop! semantics

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -98,14 +98,6 @@ jobs:
         repository: ${{ inputs.jepsen-cowsql-repo || github.repository }}
         ref: ${{ inputs.jepsen-cowsql-ref || github.ref }}
 
-    - name: Cache Jepsen (lein project) dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
-        restore-keys: |
-          ${{ runner.os }}-clojure
-
     - name: Install Go
       uses: actions/setup-go@v4
 

--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install golang
-        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
+        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential psmisc
         printf core | sudo tee /proc/sys/kernel/core_pattern
 
     - name: Install local Jepsen

--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -98,13 +98,11 @@ jobs:
         repository: ${{ inputs.jepsen-cowsql-repo || github.repository }}
         ref: ${{ inputs.jepsen-cowsql-ref || github.ref }}
 
-    - name: Install Go
-      uses: actions/setup-go@v4
-
     - name: Setup environment
       timeout-minutes: 15
       run: |
         sudo apt update
+        sudo apt install golang
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
 
@@ -116,17 +114,6 @@ jobs:
         git log -n 1
         lein install
         cd ../..
-
-    - name: Install libbacktrace
-      run: |
-        git clone https://github.com/ianlancetaylor/libbacktrace --depth 1
-        cd libbacktrace
-        autoreconf -i
-        ./configure
-        make -j4
-        sudo make install
-        sudo ldconfig
-        cd ..
 
     - name: Check out raft
       uses: actions/checkout@v3

--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -174,18 +174,6 @@ jobs:
       if: ${{ always() }}
       run: tail -n 100 store/current/jepsen.log > store/current/tail-jepsen.log
 
-    - name: Summary Artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v3
-      with:
-        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-summary
-        path: |
-          store/cowsql*/**/results.edn
-          store/cowsql*/**/latency-raw.png
-          store/cowsql*/**/tail-jepsen.log
-          !**/current/
-          !**/latest/
-
     - name: Failure Artifact
       if: ${{ failure() }}
       uses: actions/upload-artifact@v3

--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -180,6 +180,8 @@ jobs:
       with:
         name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-failure
         path: |
+          /usr/local/lib/libcowsql*
+          /usr/local/lib/libraft*
           store/cowsql*
           !**/current/
           !**/latest/

--- a/src/jepsen/cowsql/db.clj
+++ b/src/jepsen/cowsql/db.clj
@@ -282,7 +282,6 @@
         (kill! test node)
         (when tmpfs
           (db/teardown! tmpfs test node))
-        (Thread/sleep 200) ; avoid race: rm: cannot remove '/opt/cowsql/data': Directory not empty
         (c/exec :rm :-rf (app-dir test node)))
 
       db/LogFiles


### PR DESCRIPTION
The semantics of the `kill!` and `stop!` functions was backwards: `kill!` was sending `SIGTERM`, while `stop!` was sending `SIGKILL`.

Also, modify `stop!` to use `killall -w`, making sure that the process has terminated by the time the function returns.